### PR TITLE
Add ability to initialize web3 instance outside of the module and pass it into

### DIFF
--- a/multicall/call.py
+++ b/multicall/call.py
@@ -4,13 +4,20 @@ from multicall import Signature
 
 
 class Call:
-    def __init__(self, target, function, returns=None):
+    def __init__(self, target, function, returns=None, _w3=None):
         self.target = to_checksum_address(target)
+
         if isinstance(function, list):
             self.function, *self.args = function
         else:
             self.function = function
             self.args = None
+
+        if _w3 is None:
+            self.w3 = w3
+        else:
+            self.w3 = _w3
+
         self.signature = Signature(self.function)
         self.returns = returns
 
@@ -32,5 +39,5 @@ class Call:
     def __call__(self, args=None):
         args = args or self.args
         calldata = self.signature.encode_data(args)
-        output = w3.eth.call({'to': self.target, 'data': calldata})
+        output = self.w3.eth.call({'to': self.target, 'data': calldata})
         return self.decode_output(output)

--- a/multicall/multicall.py
+++ b/multicall/multicall.py
@@ -7,13 +7,20 @@ from multicall.constants import MULTICALL_ADDRESSES
 
 
 class Multicall:
-    def __init__(self, calls: List[Call]):
+    def __init__(self, calls: List[Call], _w3=None):
         self.calls = calls
+
+        if _w3 is None:
+            self.w3 = w3
+        else:
+            self.w3 = _w3
 
     def __call__(self):
         aggregate = Call(
-            MULTICALL_ADDRESSES[w3.eth.chainId],
+            MULTICALL_ADDRESSES[self.w3.eth.chainId],
             'aggregate((address,bytes)[])(uint256,bytes[])',
+            None,
+            self.w3
         )
         args = [[[call.target, call.data] for call in self.calls]]
         block, outputs = aggregate(args)


### PR DESCRIPTION
- Back compatibility saved. In case `_w3` parameter remains empty, `web3.auto` is used
- Should be pretty useful in case web3 should be initialized once or if it's a custom implementation