### PR TITLE
Add block identifier for multicall

### DIFF
--- a/multicall/call.py
+++ b/multicall/call.py
@@ -4,7 +4,7 @@ from multicall import Signature
 
 
 class Call:
-    def __init__(self, target, function, returns=None, _w3=None):
+    def __init__(self, target, function, returns=None, _w3=None, block_id=None):
         self.target = to_checksum_address(target)
 
         if isinstance(function, list):
@@ -20,6 +20,7 @@ class Call:
 
         self.signature = Signature(self.function)
         self.returns = returns
+        self.block_id = block_id
 
     @property
     def data(self):
@@ -39,5 +40,5 @@ class Call:
     def __call__(self, args=None):
         args = args or self.args
         calldata = self.signature.encode_data(args)
-        output = self.w3.eth.call({'to': self.target, 'data': calldata})
+        output = self.w3.eth.call({'to': self.target, 'data': calldata}, block_identifier=self.block_id)
         return self.decode_output(output)

--- a/multicall/multicall.py
+++ b/multicall/multicall.py
@@ -7,9 +7,9 @@ from multicall.constants import MULTICALL_ADDRESSES
 
 
 class Multicall:
-    def __init__(self, calls: List[Call], _w3=None):
+    def __init__(self, calls: List[Call], _w3=None, block_id=None):
         self.calls = calls
-
+        self.block_id = block_id
         if _w3 is None:
             self.w3 = w3
         else:
@@ -19,8 +19,9 @@ class Multicall:
         aggregate = Call(
             MULTICALL_ADDRESSES[self.w3.eth.chainId],
             'aggregate((address,bytes)[])(uint256,bytes[])',
-            None,
-            self.w3
+            returns=None,
+            _w3=self.w3,
+            block_id=self.block_id
         )
         args = [[[call.target, call.data] for call in self.calls]]
         block, outputs = aggregate(args)


### PR DESCRIPTION
Adding a block id field to multi call to be able to query read state at any given block.