### PR TITLE
Add support for Multicall2

### DIFF
--- a/multicall/call.py
+++ b/multicall/call.py
@@ -35,7 +35,10 @@ class Call:
             apply_handler = lambda handler, value: handler(success, value)
 
         if success is None or success:
-            decoded = self.signature.decode_data(output)
+            try:
+                decoded = self.signature.decode_data(output)
+            except:
+                success, decoded = False, [None] * len(self.returns)
         else:
             decoded = [None] * len(self.returns)
 

--- a/multicall/constants.py
+++ b/multicall/constants.py
@@ -16,3 +16,10 @@ MULTICALL_ADDRESSES = {
     Network.Görli: '0x77dCa2C955b15e9dE4dbBCf1246B4B85b651e50e',
     Network.xDai: '0xb5b692a88BDFc81ca69dcB1d924f59f0413A602a',
 }
+
+MULTICALL2_ADDRESSES = {
+    Network.Mainnet: '0x5ba1e12693dc8f9c48aad8770482f4739beed696',
+    Network.Kovan: '0x5ba1e12693dc8f9c48aad8770482f4739beed696',
+    Network.Rinkeby: '0x5ba1e12693dc8f9c48aad8770482f4739beed696',
+    Network.Görli: '0x5ba1e12693dc8f9c48aad8770482f4739beed696',
+}

--- a/multicall/multicall.py
+++ b/multicall/multicall.py
@@ -3,29 +3,47 @@ from typing import List
 from web3.auto import w3
 
 from multicall import Call
-from multicall.constants import MULTICALL_ADDRESSES
+from multicall.constants import MULTICALL_ADDRESSES, MULTICALL2_ADDRESSES
 
 
 class Multicall:
-    def __init__(self, calls: List[Call], _w3=None, block_id=None):
+    def __init__(self, calls: List[Call], _w3=None, block_id=None, require_success: bool=True):
         self.calls = calls
         self.block_id = block_id
+        self.require_success = require_success
+
         if _w3 is None:
             self.w3 = w3
         else:
             self.w3 = _w3
 
     def __call__(self):
+        if self.require_success is True:
+            multicall_map = MULTICALL_ADDRESSES
+            multicall_sig = 'aggregate((address,bytes)[])(uint256,bytes[])'
+        else:
+            multicall_map = MULTICALL2_ADDRESSES
+            multicall_sig = 'tryBlockAndAggregate(bool,(address,bytes)[])(uint256,uint256,(bool,bytes)[])'
+
         aggregate = Call(
-            MULTICALL_ADDRESSES[self.w3.eth.chainId],
-            'aggregate((address,bytes)[])(uint256,bytes[])',
+            multicall_map[self.w3.eth.chainId],
+            multicall_sig,
             returns=None,
             _w3=self.w3,
             block_id=self.block_id
         )
-        args = [[[call.target, call.data] for call in self.calls]]
-        block, outputs = aggregate(args)
+
+        if self.require_success is True:
+            args = [[[call.target, call.data] for call in self.calls]]
+            _, outputs = aggregate(args)
+            outputs = ((None, output) for output in outputs)
+        else:
+            args = [self.require_success, [[call.target, call.data] for call in self.calls]]
+            _, _, outputs = aggregate(args)
+
+
         result = {}
-        for call, output in zip(self.calls, outputs):
-            result.update(call.decode_output(output))
+        for call, (success, output) in zip(self.calls, outputs):
+            result.update(call.decode_output(output, success))
+
         return result

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "multicall"
-version = "0.1.1"
+version = "0.1.3"
 description = "aggregate results from multiple ethereum contract calls"
 authors = ["banteg <banteeg@gmail.com>"]
 

--- a/tests/test_multicall.py
+++ b/tests/test_multicall.py
@@ -19,3 +19,13 @@ def test_multicall():
     result = multi()
     assert isinstance(result['supply'], float)
     assert isinstance(result['balance'], float)
+
+def test_multicall_no_success():
+    multi = Multicall([
+        Call(CHAI, 'transfer(address,uint256)(bool)', [['success', lambda success, ret_flag: (success, ret_flag)]]),
+        Call(CHAI, ['balanceOf(address)(uint256)', CHAI], [['balance', lambda success, value: (success, from_ray(value))]]),
+    ], require_success=False)
+
+    result = multi()
+    assert isinstance(result['success'], tuple)
+    assert isinstance(result['balance'], tuple)


### PR DESCRIPTION
This PR adds support for makerdao's [Multicall2](https://etherscan.io/address/0x5ba1e12693dc8f9c48aad8770482f4739beed696#contracts) contract. This is useful in use cases where some call in the batch might fail, but we want the mutlicall to try and execute all included calls and not just fail.

In summary, Multicall can take an extra argument in it's constructor, specifying whether to use the new `tryBlockAndAggregate` contract method (`require_success=False`) or keep the old logic as-is. In the former case, return argument handlers receive two arguments:

1. A boolean flag, indicating the return status of the call, and
2. The return value if the call was successful, else None