### PR TITLE
add Polygon network

### DIFF
--- a/multicall/constants.py
+++ b/multicall/constants.py
@@ -7,6 +7,8 @@ class Network(IntEnum):
     Rinkeby = 4
     Görli = 5
     xDai = 100
+    Polygon = 137
+    Mumbai = 80001
 
 
 MULTICALL_ADDRESSES = {
@@ -15,4 +17,6 @@ MULTICALL_ADDRESSES = {
     Network.Rinkeby: '0x42Ad527de7d4e9d9d011aC45B31D8551f8Fe9821',
     Network.Görli: '0x77dCa2C955b15e9dE4dbBCf1246B4B85b651e50e',
     Network.xDai: '0xb5b692a88BDFc81ca69dcB1d924f59f0413A602a',
+    Network.Polygon: '0x11ce4B23bD875D7F5C6a31084f55fDe1e9A87507',
+    Network.Mumbai: '0x08411ADd0b5AA8ee47563b146743C13b3556c9Cc',
 }


### PR DESCRIPTION
Adding the address constants required to use Multicall on the Polygon and Mumbai networks (https://polygon.technology/)