### PR TITLE
refactor(utils): don't use more cores than max -1

### DIFF
--- a/multicall/constants.py
+++ b/multicall/constants.py
@@ -76,3 +76,8 @@ MULTICALL2_ADDRESSES: Dict[int,str] = {
 # With default AsyncBaseProvider settings, some dense calls will fail
 #   due to aiohttp.TimeoutError where they would otherwise succeed.
 AIOHTTP_TIMEOUT = ClientTimeout(int(os.environ.get("AIOHTTP_TIMEOUT", 30)))
+
+# Parallelism
+user_choice = max(1, int(os.environ.get("MULTICALL_PROCESSES", 1)))
+parallelism_capacity = max(1, os.cpu_count() - 1)
+NUM_PROCESSES = min(user_choice, parallelism_capacity)

--- a/multicall/utils.py
+++ b/multicall/utils.py
@@ -25,7 +25,7 @@ def chain_id(w3: Web3) -> int:
         return chainids[w3]
 
 async_w3s: Dict[Web3,Web3] = {}
-process_pool_executor = ProcessPoolExecutor(os.cpu_count() -1 )
+process_pool_executor = ProcessPoolExecutor(max(1,os.cpu_count() -1 ))
 
 def get_endpoint(w3: Web3) -> str:
     provider = w3.provider

--- a/multicall/utils.py
+++ b/multicall/utils.py
@@ -1,5 +1,6 @@
 
 import asyncio
+import os
 from concurrent.futures import ProcessPoolExecutor
 from typing import Any, Awaitable, Coroutine, Dict, Iterable
 
@@ -24,7 +25,7 @@ def chain_id(w3: Web3) -> int:
         return chainids[w3]
 
 async_w3s: Dict[Web3,Web3] = {}
-process_pool_executor = ProcessPoolExecutor(16)
+process_pool_executor = ProcessPoolExecutor(os.cpu_count() -1 )
 
 def get_endpoint(w3: Web3) -> str:
     provider = w3.provider

--- a/multicall/utils.py
+++ b/multicall/utils.py
@@ -9,7 +9,7 @@ from web3 import AsyncHTTPProvider, Web3
 from web3.eth import AsyncEth
 from web3.providers.async_base import AsyncBaseProvider
 
-from multicall.constants import AIOHTTP_TIMEOUT, Network
+from multicall.constants import AIOHTTP_TIMEOUT, NUM_PROCESSES, Network
 
 chainids: Dict[Web3,int] = {}
 
@@ -25,7 +25,7 @@ def chain_id(w3: Web3) -> int:
         return chainids[w3]
 
 async_w3s: Dict[Web3,Web3] = {}
-process_pool_executor = ProcessPoolExecutor(max(1,os.cpu_count() -1 ))
+process_pool_executor = ProcessPoolExecutor(NUM_PROCESSES)
 
 def get_endpoint(w3: Web3) -> str:
     provider = w3.provider

--- a/readme.md
+++ b/readme.md
@@ -67,4 +67,5 @@ use `Multicall(...)()` to get the result of a prepared multicall.
 
 - GAS_LIMIT: sets overridable default gas limit for Multicall to prevent out of gas errors. Default: 50,000,000
 - MULTICALL_DEBUG: if set, sets logging level for all library loggers to logging.DEBUG
+- MULTICALL_PROCESSES: pass an integer > 1 to use multiprocessing for encoding args and decoding results. Default: 1, which executes all code in the main process.
 - AIOHTTP_TIMEOUT: sets aiohttp timeout period in seconds for async calls to node. Default: 20


### PR DESCRIPTION
I would propose to limit the number of processes to `max cores - 1`.
AFAIK setting the number of processes too high might lead to parallel slowdown.