### PR TITLE
Added multicall addresses for Kava

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ env/
 cache/
 .mypy_cache
 .pytest_cache
+
+# IDE
+.idea

--- a/multicall/constants.py
+++ b/multicall/constants.py
@@ -37,6 +37,7 @@ class Network(IntEnum):
     Cronos = 25
     Optimism = 10
     OptimismKovan = 69
+    Kava = 2222
 
 MULTICALL_ADDRESSES: Dict[int,str] = {
     Network.Mainnet: '0xeefBa1e63905eF1D7ACbA5a8513c70307C1cE441',
@@ -52,6 +53,7 @@ MULTICALL_ADDRESSES: Dict[int,str] = {
     Network.Cronos: '0x5e954f5972EC6BFc7dECd75779F10d848230345F',
     Network.Optimism: '0x187C0F98FEF80E87880Db50241D40551eDd027Bf',
     Network.OptimismKovan: '0x2DC0E2aa608532Da689e89e237dF582B783E552C',
+    Network.Kava: '0x7ED7bBd8C454a1B0D9EdD939c45a81A03c20131C',
 }
 
 MULTICALL2_ADDRESSES: Dict[int,str] = {
@@ -71,6 +73,7 @@ MULTICALL2_ADDRESSES: Dict[int,str] = {
     Network.Cronos: '0x5e954f5972EC6BFc7dECd75779F10d848230345F',
     Network.Optimism: '0x2DC0E2aa608532Da689e89e237dF582B783E552C',
     Network.OptimismKovan: '0x2DC0E2aa608532Da689e89e237dF582B783E552C',
+    Network.Kava: '0x45be772faE4a9F31401dfF4738E5DC7DD439aC0b',
 }
 
 # With default AsyncBaseProvider settings, some dense calls will fail


### PR DESCRIPTION
We're using this package in our project and had to fork it to add the Network we're developing on. I'd prefer to sync with this repo than maintain a separate fork. If that's alright, I'd like to add Kava's multicall addresses.

PS: I did not include testnet as I couldn't find the contracts in Kava Testnet's [block explorer](https://explorer.testnet.kava.io/)