### PR TITLE
fix: skip web3 versions that fail for multicall+threads

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["banteg"]
 
 [tool.poetry.dependencies]
 python = "^3.8"
-web3 = "^5.27"
+web3 = "^5.27,!=5.29.*,!=5.30.*,!=5.31.*"
 eth_retry = "^0.1.8"
 
 [tool.poetry.dev-dependencies]


### PR DESCRIPTION
Fixes the first half of issue #41 