### PR TITLE
Handle both int and ClientTimeout-based values for Async timeout

### DIFF
--- a/multicall/utils.py
+++ b/multicall/utils.py
@@ -4,6 +4,7 @@ from concurrent.futures import ProcessPoolExecutor
 from typing import Any, Awaitable, Callable, Coroutine, Dict, Iterable
 
 import eth_retry
+from aiohttp import ClientTimeout
 from web3 import AsyncHTTPProvider, Web3
 from web3.eth import AsyncEth
 from web3.providers.async_base import AsyncBaseProvider
@@ -38,8 +39,13 @@ def get_async_w3(w3: Web3) -> Web3:
     if w3 in async_w3s:
         return async_w3s[w3]
     if w3.eth.is_async and isinstance(w3.provider, AsyncBaseProvider):
-        if w3.provider._request_kwargs["timeout"].total < AIOHTTP_TIMEOUT.total:
+        timeout = w3.provider._request_kwargs["timeout"]
+        if isinstance(w3.provider._request_kwargs["timeout"], ClientTimeout):
+            timeout = timeout.total
+
+        if timeout < AIOHTTP_TIMEOUT.total:
             w3.provider._request_kwargs["timeout"] = AIOHTTP_TIMEOUT
+
         async_w3s[w3] = w3
         return w3
     request_kwargs = {'timeout': AIOHTTP_TIMEOUT}

--- a/multicall/utils.py
+++ b/multicall/utils.py
@@ -40,7 +40,7 @@ def get_async_w3(w3: Web3) -> Web3:
         return async_w3s[w3]
     if w3.eth.is_async and isinstance(w3.provider, AsyncBaseProvider):
         timeout = w3.provider._request_kwargs["timeout"]
-        if isinstance(w3.provider._request_kwargs["timeout"], ClientTimeout):
+        if isinstance(timeout, ClientTimeout):
             timeout = timeout.total
 
         if timeout < AIOHTTP_TIMEOUT.total:


### PR DESCRIPTION
Timeout values are ints, but an attribute `.total` was being called, leading to errors when passing in web3 instances into Call