### PR TITLE
Updated the example calls to use `returns` tuples

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -22,9 +22,9 @@ def from_wei(value):
     return value / 1e18
 
 multi = Multicall([
-    Call(MKR_TOKEN, ['balanceOf(address)(uint256)', MKR_WHALE], [['whale', from_wei]]),
-    Call(MKR_TOKEN, ['balanceOf(address)(uint256)', MKR_FISH], [['fish', from_wei]]),
-    Call(MKR_TOKEN, 'totalSupply()(uint256)', [['supply', from_wei]]),
+    Call(MKR_TOKEN, ['balanceOf(address)(uint256)', MKR_WHALE], [('whale', from_wei)]),
+    Call(MKR_TOKEN, ['balanceOf(address)(uint256)', MKR_FISH], [('fish', from_wei)]),
+    Call(MKR_TOKEN, 'totalSupply()(uint256)', [('supply', from_wei)]),
 ])
 
 multi()  # {'whale': 566437.0921992733, 'fish': 7005.0, 'supply': 1000003.1220798912}
@@ -33,7 +33,7 @@ multi()  # {'whale': 566437.0921992733, 'fish': 7005.0, 'supply': 1000003.122079
 Call(MKR_TOKEN, ['balanceOf(address)(uint256)', MKR_WHALE])()
 Call(MKR_TOKEN, 'balanceOf(address)(uint256)')(MKR_WHALE)
 # return values processing
-Call(MKR_TOKEN, 'totalSupply()(uint256)', [['supply', from_wei]])()
+Call(MKR_TOKEN, 'totalSupply()(uint256)', [('supply', from_wei)])()
 ```
 
 for a full example, see implementation of [daistats](https://github.com/banteg/multicall.py/blob/master/examples/daistats.py).
@@ -51,7 +51,7 @@ use `encode_data(args)` with input args to get the calldata. use `decode_data(ou
 
 - `target` is the `to` address which is supplied to `eth_call`.
 - `function` can be either seth-style signature of `method(input,types)(output,types)` or a list of `[signature, *args]`.
-- `returns` is a list of `[name, handler]` for return values. if `returns` argument is omitted, you get a tuple, otherwise you get a dict. to skip processing of a value, pass `None` as a handler.
+- `returns` is a list of tuples of `(name, handler)` for return values. if `returns` argument is omitted, you get a tuple, otherwise you get a dict. to skip processing of a value, pass `None` as a handler.
 
 use `Call(...)()` with predefined args or `Call(...)(args)` to reuse a prepared call with different args.
 


### PR DESCRIPTION
The example code in the` readme.md` has the `returns` param passed a list instead of a tuple. 

```
multi = Multicall([
    Call(MKR_TOKEN, ['balanceOf(address)(uint256)', MKR_WHALE], [['whale', from_wei]]),
    Call(MKR_TOKEN, ['balanceOf(address)(uint256)', MKR_FISH], [['fish', from_wei]]),
    Call(MKR_TOKEN, 'totalSupply()(uint256)', [['supply', from_wei]]),
])

multi()  # {'whale': 566437.0921992733, 'fish': 7005.0, 'supply': 1000003.1220798912}

# seth-style calls
Call(MKR_TOKEN, ['balanceOf(address)(uint256)', MKR_WHALE])()
Call(MKR_TOKEN, 'balanceOf(address)(uint256)')(MKR_WHALE)
# return values processing
Call(MKR_TOKEN, 'totalSupply()(uint256)', [['supply', from_wei]])()
```

The type hinting inside of Call ` returns: Optional[Iterable[Tuple[str,Callable]]] = None` is for a tuple but the example code passes in a list.

```
class Call:
    def __init__(
        self, 
        target: AnyAddress, 
        function: Union[str,Iterable[Union[str,Any]]], # 'funcName(dtype)(dtype)' or ['funcName(dtype)(dtype)', input0, input1, ...]
        returns: Optional[Iterable[Tuple[str,Callable]]] = None, 
        block_id: Optional[int] = None, 
        gas_limit: Optional[int] = None,
        state_override_code: Optional[str] = None, 
        # This needs to be None in order to use process_pool_executor
        _w3: Web3 = None
    ) -> None:
```
https://github.com/banteg/multicall.py/blob/master/multicall/call.py

This is a simple change to the example in the `readme.md` so that it matches with the type hinting in `Call`

