### PR TITLE
Update instance block_id on execution

### DIFF
--- a/multicall/multicall.py
+++ b/multicall/multicall.py
@@ -85,10 +85,10 @@ class Multicall:
             try:
                 args = await run_in_subprocess(get_args, calls, self.require_success)
                 if self.require_success is True:
-                    _, outputs = await self.aggregate.coroutine(args)
+                    self.block_id, outputs = await self.aggregate.coroutine(args)
                     outputs = await run_in_subprocess(unpack_aggregate_outputs, outputs)
                 else:
-                    _, _, outputs = await self.aggregate.coroutine(args)
+                    self.block_id, _, outputs = await self.aggregate.coroutine(args)
                 outputs = await gather([
                     run_in_subprocess(Call.decode_output, output, call.signature, call.returns, success)
                     for call, (success, output) in zip(calls, outputs)


### PR DESCRIPTION
Addresses #39 in a slightly different way by populating the `block_id` attribute. Presumably, this would be the same as the input if defining a block_id on call. But most importantly, the executed block number is made available for `latest`.

Since multicall.py [effectively](https://github.com/banteg/multicall.py/blob/71c5e40c9daf74bf149bdb9c3b4b4e70596cb22f/multicall/multicall.py#L49-L52) no longer uses MC1 contracts, I don't see any compatibility issues.