### PR TITLE
Add access to core Multicall contract methods

### DIFF
--- a/multicall/multicall.py
+++ b/multicall/multicall.py
@@ -109,6 +109,49 @@ class Multicall:
         )
         return dict(mapcat(dict.items, concat(batches)))
 
+    def _contract_method(self, request_signature: list, return_signature: tuple) -> None:
+        self.calls.append(Call(self.multicall_address, request_signature, [return_signature]))
+        
+    def add_base_fee(self, return_signature: tuple = ('base_fee', None)) -> None:
+        signature = ['getBasefee()(uint256)']
+        self._contract_method(signature, return_signature)
+
+    def add_block_hash(self, block_number: int, return_signature: tuple = ('block_hash', None)) -> None:
+        signature = ['getBlockHash(uint256)(bytes32)', block_number]
+        self._contract_method(signature, return_signature)
+
+    def add_block_number(self, return_signature: tuple = ('block_number', None)) -> None:
+        signature = ['getBlockNumber()(uint256)']
+        self._contract_method(signature, return_signature)
+
+    def add_chain_id(self, return_signature: tuple = ('chain_id', None)) -> None:
+        signature = ['getChainId()(uint256)']
+        self._contract_method(signature, return_signature)
+
+    def add_block_coinbase(self, return_signature: tuple = ('coinbase', None)) -> None:
+        signature = ['getCurrentBlockCoinbase()(address)']
+        self._contract_method(signature, return_signature)
+
+    def add_block_difficulty(self, return_signature: tuple = ('difficulty', None)) -> None:
+        signature = ['getCurrentBlockDifficulty()(address)']
+        self._contract_method(signature, return_signature)
+
+    def add_block_gas_limit(self, return_signature: tuple = ('gas_limit', None)) -> None:
+        signature = ['getCurrentBlockGasLimit()(uint256)']
+        self._contract_method(signature, return_signature)
+
+    def add_block_timestamp(self, return_signature: tuple = ('timestamp', None)) -> None:
+        signature = ['getCurrentBlockTimestamp()(uint256)']
+        self._contract_method(signature, return_signature)
+
+    def add_eth_balance(self, address: AnyAddress, return_signature: tuple = ('eth_balance', None)) -> None:
+        signature = ['getEthBalance(address)(uint256)', address]
+        self._contract_method(signature, return_signature)
+
+    def add_last_block_hash(self, return_signature: tuple = ('last_block_hash', None)) -> None:
+        signature = ['getLastBlockHash()(bytes32)']
+        self._contract_method(signature, return_signature)
+    
     async def fetch_outputs(
         self, calls: List[Call], ConnErr_retries: int = 0, id: str = ""
     ) -> List[CallResponse]:

--- a/tests/test_multicall.py
+++ b/tests/test_multicall.py
@@ -9,6 +9,7 @@ from multicall.utils import await_awaitable
 
 CHAI = "0x06AF07097C9Eeb7fD685c692751D5C66dB49c215"
 WHOAMI = "0x66659E34096372C1aad8d459559432Ab0aa64569"
+WETH = "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"
 DUMMY_CALL = Call(CHAI, "totalSupply()(uint)", [["totalSupply", None]])
 batcher.step = 10_000
 
@@ -158,6 +159,34 @@ def test_batcher_split_calls_odd():
     assert sum(len(batch) for batch in split) == len(calls)
     assert len(split[0]) == 14_999
     assert len(split[1]) == 15_000
+
+def test_multicalll_contract_methods():
+    calls = [Call(CHAI, ["totalSupply()(uint)", CHAI, 1], [["totalSupply", None]])]
+    multi = Multicall(calls)
+    multi.add_base_fee()
+    multi.add_block_hash(1)
+    multi.add_block_number()
+    multi.add_chain_id()
+    multi.add_block_coinbase()
+    multi.add_block_difficulty()
+    multi.add_block_gas_limit()
+    multi.add_block_timestamp()
+    multi.add_eth_balance(CHAI, ('custom_balance', None))
+    multi.add_last_block_hash()
+
+    result = multi()
+    print(result)
+    assert isinstance(result["totalSupply"], int)
+    assert isinstance(result["base_fee"], int)
+    assert isinstance(result["block_hash"], bytes)
+    assert isinstance(result["block_number"], int)
+    assert isinstance(result["chain_id"], int)
+    assert isinstance(result["coinbase"], str)
+    assert isinstance(result["difficulty"], None | int)
+    assert isinstance(result["gas_limit"], int)
+    assert isinstance(result["timestamp"], int)
+    assert isinstance(result["custom_balance"], int)
+    assert isinstance(result["last_block_hash"], bytes)
 
 
 @pytest.mark.skip(reason="long running")


### PR DESCRIPTION
The core Multicall contracts have various methods for accessing base attributes of the chain at the executed block number, the most important (IMO) being `getEthBalance()` and `getCurrentBlockTimestamp()`.

`getBlockNumber()` is slightly redundant since it's already provided via `aggregate()` / `tryBlockAndAggregate()` (exposed via #74), but added, along with all other methods, for completeness.

One real-world example that I use in my own code:

```py
calls = [
	Call(wrapped_native, ['balanceOf(address)(uint256)', my_address], [['weth_balance', None]])
]
mc = Multicall(calls, _w3=rpc)
mc.get_eth_balance(my_address)

results = await mc.coroutine()
// {'weth_balance': 4858579460227, 'eth_balance': 60178543536789}
```
The return signature can be overridden to a different key or formatter.

Edits to overall structure or nomenclature welcome.