### PR TITLE
add support for web3py version >7

### DIFF
--- a/multicall/utils.py
+++ b/multicall/utils.py
@@ -74,19 +74,17 @@ def get_async_w3(w3: Web3) -> Web3:
     else:
         provider = AsyncHTTPProvider(endpoint, request_kwargs)
 
-    kwargs = {provider: provider}
-    
-    # Older versions of web3.py (v6 and below) use 'middlewares' instead of 'middleware'.
-    major_version = int(web3.__version__.split('.')[0])
-    if major_version >= 7:
-        kwargs["middleware"] = []
+    # In older web3 versions, AsyncHTTPProvider objects come
+    # with incompatible synchronous middlewares by default.
+    if AsyncWeb3 is not None:
+        # Older versions of web3.py (v6 and below) use 'middlewares' instead of 'middleware'.
+        major_version = int(web3.__version__.split('.')[0])
+        if major_version >= 7:
+            async_w3 = AsyncWeb3(provider, middleware=[])
+        else:
+            async_w3 = AsyncWeb3(provider, middlewares=[])
     else:
-        kwargs["middlewares"] = []
-
-    w3_class = Web3 if AsyncWeb3 is None else AsyncWeb3
-    async_w3 = w3_class(**kwargs)
-
-    if w3_class is Web3:
+        async_w3 = Web3(provider=provider, middlewares=[])
         async_w3.eth = AsyncEth(async_w3)
 
     async_w3s[w3] = async_w3  # type: ignore [assignment]

--- a/multicall/utils.py
+++ b/multicall/utils.py
@@ -77,7 +77,7 @@ def get_async_w3(w3: Web3) -> Web3:
     # Older versions of web3.py (v6 and below) use 'middlewares' instead of 'middleware'.
     major_version = int(web3.__version__.split('.')[0])
     key = "middleware" if major_version >= 7 else "middlewares"
-    kwargs = {key: []}
+    kwargs = {key: []}  # type: ignore [dict-item]
 
     w3_class = AsyncWeb3 if AsyncWeb3 else Web3  # type: ignore [truthy-function]
     async_w3 = w3_class(provider=provider, **kwargs)  # type: ignore [call-arg]

--- a/multicall/utils.py
+++ b/multicall/utils.py
@@ -74,15 +74,19 @@ def get_async_w3(w3: Web3) -> Web3:
     else:
         provider = AsyncHTTPProvider(endpoint, request_kwargs)
 
+    kwargs = {provider: provider}
+    
     # Older versions of web3.py (v6 and below) use 'middlewares' instead of 'middleware'.
     major_version = int(web3.__version__.split('.')[0])
-    key = "middleware" if major_version >= 7 else "middlewares"
-    kwargs = {key: []}  # type: ignore [dict-item]
+    if major_version >= 7:
+        kwargs["middleware"] = []
+    else:
+        kwargs["middlewares"] = []
 
-    w3_class = AsyncWeb3 if AsyncWeb3 else Web3  # type: ignore [truthy-function]
-    async_w3 = w3_class(provider=provider, **kwargs)  # type: ignore [call-arg]
+    w3_class = Web3 if AsyncWeb3 is None else AsyncWeb3
+    async_w3 = w3_class(**kwargs)
 
-    if not AsyncWeb3:  # type: ignore [truthy-function]
+    if w3_class is Web3:
         async_w3.eth = AsyncEth(async_w3)
 
     async_w3s[w3] = async_w3  # type: ignore [assignment]


### PR DESCRIPTION
Change the AsyncWeb3 paramater to 'middleware' when on web3py version >=7