### PR TITLE
Omit RSK from Overrides

### DIFF
--- a/multicall/constants.py
+++ b/multicall/constants.py
@@ -655,6 +655,7 @@ NO_STATE_OVERRIDE: Final = {
     Network.Kovan,
     Network.Fuse,
     Network.PolygonzkEVM,
+    Network.RSK,
     Network.ZkSync,
 }
 


### PR DESCRIPTION
Sometime recently, Rootstock nodes stopped allowing State Overrides